### PR TITLE
BeautifulSoup to handle content as XML for DFXP.

### DIFF
--- a/pycaption/dfxp.py
+++ b/pycaption/dfxp.py
@@ -47,7 +47,7 @@ class DFXPReader(BaseReader):
         if type(content) != unicode:
             raise RuntimeError('The content is not a unicode string.')
 
-        dfxp_soup = BeautifulSoup(content)
+        dfxp_soup = BeautifulSoup(content, 'xml')
         captions = CaptionSet()
 
         # Each div represents all the captions for a single language.


### PR DESCRIPTION
Have the Content being handled as XML for DFXP files, if CDATA tags are being used inside the body of the copy the CDATA content is being ignored completely.
